### PR TITLE
Fix the gameStatusMessage bug

### DIFF
--- a/src/components/Grid.vue
+++ b/src/components/Grid.vue
@@ -88,7 +88,10 @@ export default {
   		}
 
 			this.gameStatusMessage = `${this.activePlayer}'s turn`
-  	}
+  	},
+	activePlayer(){
+		this.gameStatusMessage = `${this.activePlayer}'s turn`
+	}
   },
 
   methods: {


### PR DESCRIPTION
Hello, this project is interesting. And this PR is to fix a small bug I found when playing with it. That is, the gameStatusMessage doesn't change (O's turn -> X's turn or vice versa) when playing. the code here( in Grid.Vue):

```Vue
watch: {
  	// watches for change in the value of gameStatus and changes the status 
  	// message and color accordingly
  	gameStatus () {
  		if (this.gameStatus === 'win') {
  			this.gameStatusColor = 'statusWin'

  			return
  		} else if (this.gameStatus === 'draw') {
  			this.gameStatusColor = 'statusDraw'

  			this.gameStatusMessage = 'Draw !'
  			
  			return
  		}

			this.gameStatusMessage = `${this.activePlayer}'s turn`
  	}
```
does not actually assign a new value to `this.gameStatusMessage` because gameStatus does not change UNLESS WIN OR DRAW. Here to fix it is "watch" `this.activePlayer` :
```Vue
activePlayer(){
		this.gameStatusMessage = `${this.activePlayer}'s turn`
	}
```
Whether u merge this PR or not, thanks.